### PR TITLE
Append events to a file, does not read yet

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="net.bruhat.justdid">
 
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/net/bruhat/justdid/MainActivity.kt
+++ b/app/src/main/java/net/bruhat/justdid/MainActivity.kt
@@ -1,17 +1,64 @@
 package net.bruhat.justdid
 
-import androidx.appcompat.app.AppCompatActivity
+import android.Manifest
+import android.app.Activity
+import android.content.pm.PackageManager
 import android.os.Bundle
+import android.os.Environment.getExternalStorageDirectory
 import android.view.View
 import android.widget.EditText
 import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.ActivityCompat
+import java.io.File
+import java.nio.charset.StandardCharsets
 import java.text.SimpleDateFormat
-import java.util.Date
+import java.util.*
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+    }
+
+    // Storage Permissions
+    private val REQUEST_EXTERNAL_STORAGE = 1
+    private val PERMISSIONS_STORAGE = arrayOf<String>(
+        Manifest.permission.READ_EXTERNAL_STORAGE,
+        Manifest.permission.WRITE_EXTERNAL_STORAGE
+    )
+
+    /**
+     * Checks if the app has permission to write to device storage
+     *
+     * If the app does not has permission then the user will be prompted to grant permissions
+     *
+     * @param activity
+     */
+    private fun verifyStoragePermissions(activity: Activity?) {
+        // Check if we have write permission
+        val permission =
+            ActivityCompat.checkSelfPermission(
+                activity!!,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE
+            )
+        if (permission != PackageManager.PERMISSION_GRANTED) {
+            // We don't have permission so prompt the user
+            ActivityCompat.requestPermissions(
+                activity,
+                PERMISSIONS_STORAGE,
+                REQUEST_EXTERNAL_STORAGE
+            )
+        }
+    }
+
+    private fun writeString(s: String) {
+        verifyStoragePermissions(this);
+        val name = getString( R.string.just_did_filename)
+        // path = /data/user/0/net.bruhat.justdid/files/
+        val path = getFilesDir()
+        val fullPath = File(path, name)
+        fullPath.appendText(s,StandardCharsets.UTF_8)
     }
 
     private fun millisToString(millis: Long): String {
@@ -24,7 +71,10 @@ class MainActivity : AppCompatActivity() {
     fun addToTaskLog(view: View) {
         val taskLog = findViewById<TextView>(R.id.taskLog)
         val task    = findViewById<EditText>(R.id.editText)
-        val dateTimeStr = millisToString(System.currentTimeMillis())
+        val epoch = System.currentTimeMillis()
+        writeString("" + epoch + " " + task.text + "\n")
+
+        val dateTimeStr = millisToString(epoch)
         val newText = dateTimeStr + " " + task.text + "\n" + taskLog.text
         taskLog.setText( newText.toCharArray(), 0, newText.length )
         task.setText("")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">JustDid</string>
+    <string name="just_did_filename">just-did.txt</string>
 </resources>


### PR DESCRIPTION
This adds appending events to a file before.

The display is still only the events from this session,
but it could be extended to make the display read from the file.

Co-authored-by: Philippe Bruhat (BooK) <book@cpan.org>